### PR TITLE
chore: promote spjgh to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/spjgh/spjgh-ingress.yaml
+++ b/config-root/namespaces/jx-staging/spjgh/spjgh-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: spjgh/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'spjgh'
+  name: spjgh
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: spjgh
+              servicePort: 80
+      host: spjgh-jx-staging.prod.jx.nile-global.cloud

--- a/config-root/namespaces/jx-staging/spjgh/spjgh-spjgh-deploy.yaml
+++ b/config-root/namespaces/jx-staging/spjgh/spjgh-spjgh-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: spjgh/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spjgh-spjgh
+  labels:
+    draft: draft-app
+    chart: "spjgh-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'spjgh'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: spjgh-spjgh
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: spjgh-spjgh
+    spec:
+      serviceAccountName: spjgh-spjgh
+      containers:
+        - name: spjgh
+          image: "ghcr.io/mashaya/spjgh:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/spjgh/spjgh-spjgh-sa.yaml
+++ b/config-root/namespaces/jx-staging/spjgh/spjgh-spjgh-sa.yaml
@@ -1,0 +1,10 @@
+# Source: spjgh/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spjgh-spjgh
+  annotations:
+    meta.helm.sh/release-name: 'spjgh'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/spjgh/spjgh-svc.yaml
+++ b/config-root/namespaces/jx-staging/spjgh/spjgh-svc.yaml
@@ -1,0 +1,20 @@
+# Source: spjgh/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: spjgh
+  labels:
+    chart: "spjgh-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'spjgh'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: spjgh-spjgh

--- a/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-rgh9j-pod.yaml
+++ b/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-rgh9j-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-ohga7"
+  name: "jenkins-ui-test-rgh9j"
   namespace: myjenkins
   annotations:
     "helm.sh/hook": test-success

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,6 +119,12 @@
 	      <td><a href='http://go-lang-test-jx-staging.prod.jx.nile-global.cloud'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> spjgh </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://spjgh-jx-staging.prod.jx.nile-global.cloud'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -287,3 +287,18 @@
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/go-lang-test
     version: 0.0.4
+  - apiVersion: v1
+    appVersion: 0.0.1
+    applicationUrl: http://spjgh-jx-staging.prod.jx.nile-global.cloud
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-06-02T18:06:44Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: spjgh
+      url: http://spjgh-jx-staging.prod.jx.nile-global.cloud
+    lastDeployed: "2021-06-02T18:06:44Z"
+    name: spjgh
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-staging/spjgh
+    version: 0.0.1

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/spjgh
   version: 0.0.1
   name: spjgh
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: go-lang-test
   values:
   - jx-values.yaml
+- chart: dev/spjgh
+  version: 0.0.1
+  name: spjgh
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote spjgh to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
